### PR TITLE
Custom build for Snowflake

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+ - sfe1ed40
+channels:
+ - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,13 @@ source:
   sha256: 6f26c99ecfd3f715932e470836c2dd80fb55509df18955ff863f0212d19c23ad
 
 build:
-  number: 0
+  # STOP!!!
+  # This is a custom build for the Snowflake private channel, because they need
+  # this package to depend on opencv-python-headless (present only on their channel)
+  # instead of the regular OpenCV. If you are updating this package for defaults
+  # then please reset this back to 0 but also remove the dependency on the 
+  # headless version.
+  number: 1
   # torchvision currently isn't available on s390x and ppc64le.
   skip: True  # [s390x or ppc64le]
   skip: True  # [py<37]
@@ -30,7 +36,10 @@ requirements:
     - python
     - pytorch
     - torchvision >=0.5
-    - py-opencv >=4.6.0
+    # Snowflake wants this package to depend on the headless
+    # version of OpenCV.
+    # - pyopencv >=4.6.0
+    - opencv-python-headless >=4.6.0
     - scipy
     - numpy
     - pillow


### PR DESCRIPTION
This is a custom build of this package for Snowflake, in that it depends on the headless version of OpenCV (`opencv-python-headless`) instead of the regular OpenCV. The `abs.yaml` is needed because:
1. `opencv-python-headless` is only present on the Snowflake channel.
2. This package is destined for the Snowflake channel.
The build number has been incremented to differentiate it from the package on the defaults channel (in the event that the build hashes collide).